### PR TITLE
改为不依赖mybatis，从Druid层支持租户以支持任意JPA框架的实现方案

### DIFF
--- a/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/DruidTenantContext.java
+++ b/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/DruidTenantContext.java
@@ -1,0 +1,42 @@
+package com.github.osinn.druid.multi.tenant.plugin.filter;
+
+import com.github.osinn.druid.multi.tenant.plugin.service.ITenantService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 重新封装skipParser 以支持 Aop
+ *
+ * @author KisChang
+ */
+@Slf4j
+@Component
+public abstract class DruidTenantContext implements ITenantService {
+
+    @Override
+    public boolean skipParser() {
+        if (isIgnoreTenantId()) {
+            return true;
+        }
+        return false;
+    }
+
+    // 支持Aop方式忽略租户
+    private static final ThreadLocal<Boolean> IGNORE_TENANT_ID =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    /** 开启忽略租户 */
+    public static void ignoreTenantId() {
+        IGNORE_TENANT_ID.set(Boolean.TRUE);
+    }
+
+    /** 是否忽略租户 */
+    public static boolean isIgnoreTenantId() {
+        return Boolean.TRUE.equals(IGNORE_TENANT_ID.get());
+    }
+
+    /** 清理（必须在 finally 调用） */
+    public static void clear() {
+        IGNORE_TENANT_ID.remove();
+    }
+}

--- a/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/DruidTenantFilter.java
+++ b/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/DruidTenantFilter.java
@@ -1,0 +1,72 @@
+package com.github.osinn.druid.multi.tenant.plugin.filter;
+
+import com.alibaba.druid.filter.FilterAdapter;
+import com.alibaba.druid.filter.FilterChain;
+import com.alibaba.druid.proxy.jdbc.ConnectionProxy;
+import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
+import com.alibaba.druid.proxy.jdbc.PreparedStatementProxy;
+import com.github.osinn.druid.multi.tenant.plugin.handler.TenantInfoHandler;
+import com.github.osinn.druid.multi.tenant.plugin.parser.DefaultSqlParser;
+import com.github.osinn.druid.multi.tenant.plugin.service.ITenantService;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
+
+/**
+ * Druid 的过滤器
+ *
+ * @author KisChang
+ */
+@Component
+public class DruidTenantFilter extends FilterAdapter implements BeanFactoryPostProcessor {
+
+    private static ConfigurableListableBeanFactory beanFactory; // Spring应用上下文环境
+    private static final DefaultSqlParser DEFAULT_SQL_PARSER = new DefaultSqlParser();
+
+    public DruidTenantFilter() {
+    }
+
+    @Override
+    public void init(DataSourceProxy dataSource) {
+        super.init(dataSource);
+        DEFAULT_SQL_PARSER.setTenantService(beanFactory.getBean(ITenantService.class));
+        DEFAULT_SQL_PARSER.setTenantInfoHandler(beanFactory.getBean(TenantInfoHandler.class));
+    }
+
+    /* 这部分以DDL 为主
+    @Override
+    public boolean statement_execute(
+            FilterChain chain,
+            com.alibaba.druid.proxy.jdbc.StatementProxy statement,
+            String sql) throws SQLException {
+        return chain.statement_execute(statement, rewriteSql(sql));
+    }*/
+
+    @Override
+    public PreparedStatementProxy connection_prepareStatement(
+            FilterChain chain,
+            ConnectionProxy connection,
+            String sql) throws SQLException {
+        String newSql;
+        if (DEFAULT_SQL_PARSER.isSkipParser()) {
+            newSql = sql;
+        } else if (DEFAULT_SQL_PARSER.isIgnoreDynamicDatasource()) {
+            newSql = sql;
+        } else {
+            // 处理 SQL
+            String url = connection.getRawObject().getMetaData().getURL();
+            Object paramTenantId = DEFAULT_SQL_PARSER.getTenantInfoHandler().getTenantIds();
+            newSql = DEFAULT_SQL_PARSER.setTenantParameter(url, sql, paramTenantId);
+        }
+        // 使用修改后的 SQL
+        return chain.connection_prepareStatement(connection, newSql);
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory configurableListableBeanFactory) throws BeansException {
+        beanFactory = configurableListableBeanFactory;
+    }
+}

--- a/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/DruidTenantProcessor.java
+++ b/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/DruidTenantProcessor.java
@@ -1,0 +1,74 @@
+package com.github.osinn.druid.multi.tenant.plugin.filter;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.github.osinn.druid.multi.tenant.plugin.handler.TenantInfoHandler;
+import com.github.osinn.druid.multi.tenant.plugin.service.ITenantService;
+import com.github.osinn.druid.multi.tenant.plugin.starter.TenantProperties;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * 通过 BeanPostProcessor 给Druid添加一个自定义的过滤器 DruidTenantFilter
+ *
+ * @author KisChang
+ * @see com.github.osinn.druid.multi.tenant.plugin.filter.DruidTenantFilter
+ */
+@Configuration
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@ConditionalOnProperty(name = "mybatis.tenant.config.enable", havingValue = "true")
+public class DruidTenantProcessor implements BeanPostProcessor {
+
+    @Bean
+    public TenantInfoHandler bean(ITenantService tenantService, TenantProperties tenantProperties) {
+        return new TenantInfoHandler() {
+            public List<Object> getTenantIds() {
+                return tenantService.getTenantIds();
+            }
+
+            public List<String> ignoreTableName() {
+                return tenantProperties.getIgnoreTableName();
+            }
+
+            public List<String> ignoreMatchTableAlias() {
+                return tenantProperties.getIgnoreMatchTableAlias();
+            }
+
+            public List<String> ignoreTableNamePrefix() {
+                return tenantProperties.getIgnoreTableNamePrefix();
+            }
+
+            public String getTenantIdColumn() {
+                return tenantProperties.getTenantIdColumn();
+            }
+
+            public List<String> ignoreDynamicDatasource() {
+                return tenantProperties.getIgnoreDynamicDatasource();
+            }
+
+            public DbType getDbType() {
+                return tenantProperties.getDbType();
+            }
+        };
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof DruidDataSource) {
+            try {
+                ((DruidDataSource) bean).addFilters(DruidTenantFilter.class.getTypeName());
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return bean;
+    }
+
+}

--- a/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/IgnoreTenantIdFieldAdvisor.java
+++ b/src/main/java/com/github/osinn/druid/multi/tenant/plugin/filter/IgnoreTenantIdFieldAdvisor.java
@@ -1,0 +1,49 @@
+package com.github.osinn.druid.multi.tenant.plugin.filter;
+
+import com.github.osinn.druid.multi.tenant.plugin.annotation.IgnoreTenantIdField;
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.support.AbstractBeanFactoryPointcutAdvisor;
+import org.springframework.aop.support.StaticMethodMatcherPointcut;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+/**
+ * 自定义实现 pointcut 让 IgnoreTenantIdField 可以写在接口上
+ * （类似Mybatis plus、Fenix Jpa等框架也可以使用，不需要 TenantInfoHandler.IGNORE_TENANT_ID_METHODS 去处理了）
+ *
+ * @author KisChang
+ */
+@Component
+public class IgnoreTenantIdFieldAdvisor extends AbstractBeanFactoryPointcutAdvisor {
+
+    private final StaticMethodMatcherPointcut pointcut = new StaticMethodMatcherPointcut() {
+        @Override
+        public boolean matches(Method method, Class<?> targetClass) {
+            // 直接使用spring工具包，来获取method上的注解（会找父类上的注解）
+            return AnnotatedElementUtils.hasAnnotation(method, IgnoreTenantIdField.class);
+        }
+    };
+
+    private final Advice advice = (MethodInterceptor) invocation -> {
+        try {
+            DruidTenantContext.ignoreTenantId();
+            return invocation.proceed();
+        } finally {
+            DruidTenantContext.clear();
+        }
+    };
+
+    @Override
+    public Advice getAdvice() {
+        return advice;
+    }
+
+    @Override
+    public Pointcut getPointcut() {
+        return pointcut;
+    }
+}


### PR DESCRIPTION
现在的实现其实是从druid 的 sql 去解析并加入了租户支持
并不依赖于mybatis的任何功能

所以如果扩展到druid上，这个项目其实可以支持任意jpa框架

我在我的项目里测试通过这些代码实现了对任意框架的支持，不依赖mybatis

1. 从druid去拦截sql，并通过配置直接加到druid filters中
2. IgnoreTenantIdField 注解改用aop实现，可以直接写在接口上
3. 添加一些ThreadLocal 以支持这个改动